### PR TITLE
Pad partial file prompt batches

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -210,8 +210,9 @@ def main():
         with open(opt.from_file, "r") as f:
             data = f.read().splitlines()
             remainder = len(data) % batch_size
-            if remainder > 0:
-                data = data + [data[-1] * remainder]
+            if (remainder > 0) and (batch_size > remainder):
+                pad_length = (batch_size - remainder)
+                data = data + pad_length * [data[-1]]
             data = list(chunk(data, batch_size))
 
     sample_path = os.path.join(outpath, "samples")

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -209,6 +209,9 @@ def main():
         print(f"reading prompts from {opt.from_file}")
         with open(opt.from_file, "r") as f:
             data = f.read().splitlines()
+            remainder = len(data) % batch_size
+            if remainder > 0:
+                data = data + [data[-1] * remainder]
             data = list(chunk(data, batch_size))
 
     sample_path = os.path.join(outpath, "samples")


### PR DESCRIPTION
If the number of prompts is not a multiple of the size of the batch, it causes errors.

To avoid this, we can run the final prompt some additional times to pad out the last batch.

This is just one possible solution to the issue, of course.