### PR TITLE
The img_callback function in all the samplers should take img, not…

### DIFF
--- a/ldm/models/diffusion/ddim.py
+++ b/ldm/models/diffusion/ddim.py
@@ -154,7 +154,7 @@ class DDIMSampler(object):
                                       unconditional_conditioning=unconditional_conditioning)
             img, pred_x0 = outs
             if callback: callback(i)
-            if img_callback: img_callback(pred_x0, i)
+            if img_callback: img_callback(img, i)
 
             if index % log_every_t == 0 or index == total_steps - 1:
                 intermediates['x_inter'].append(img)

--- a/ldm/models/diffusion/plms.py
+++ b/ldm/models/diffusion/plms.py
@@ -161,7 +161,7 @@ class PLMSSampler(object):
             if len(old_eps) >= 4:
                 old_eps.pop(0)
             if callback: callback(i)
-            if img_callback: img_callback(pred_x0, i)
+            if img_callback: img_callback(img, i)
 
             if index % log_every_t == 0 or index == total_steps - 1:
                 intermediates['x_inter'].append(img)


### PR DESCRIPTION
… pred_x0. This allows us to pass a function to the sampler that can mutate the image at each step, and is also more consistent with the img_callback function in ddpm.py

This is a tiny change that will have a HUGE IMPACT on the flexibility of the inference code!