### PR TITLE
Don't overwrite images, instead find an unused filename.

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -315,6 +315,10 @@ def main():
                                 x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
                                 img = Image.fromarray(x_sample.astype(np.uint8))
                                 img = put_watermark(img, wm_encoder)
+
+                                while os.path.exists(os.path.join(sample_path, f"{base_count:05}.png")):
+                                    base_count += 1
+
                                 img.save(os.path.join(sample_path, f"{base_count:05}.png"))
                                 base_count += 1
 
@@ -331,6 +335,10 @@ def main():
                     grid = 255. * rearrange(grid, 'c h w -> h w c').cpu().numpy()
                     img = Image.fromarray(grid.astype(np.uint8))
                     img = put_watermark(img, wm_encoder)
+
+                    while os.path.exists(os.path.join(outpath, f'grid-{grid_count:04}.png')):
+                        grid_count += 1
+
                     img.save(os.path.join(outpath, f'grid-{grid_count:04}.png'))
                     grid_count += 1
 


### PR DESCRIPTION
In horror, I lost some of my images when I deleted some, then it was reusing filenames. This fixes that. Just never overwrite an existing image, instead, keep incrementing until it's unused.