### PR TITLE
use model.to(device) to instead of model.cuda()

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -60,8 +60,6 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
-    model.eval()
     return model
 
 
@@ -241,6 +239,7 @@ def main():
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     model = model.to(device)
+    model.eval()
 
     if opt.plms:
         sampler = PLMSSampler(model)


### PR DESCRIPTION
load_model_from_config may use cpu to eval the model,
return the model and call eval() after the model.to(device)
can solve this problem.