### PR TITLE
fix script/img2img.py path resolution

### DIFF
--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -15,6 +15,8 @@ from contextlib import nullcontext
 import time
 from pytorch_lightning import seed_everything
 
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
 from ldm.util import instantiate_from_config
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler


### PR DESCRIPTION
Running `python scripts/img2img.py` fails with error:

```
Traceback (most recent call last):
  File "/Users/blair/code/stuff/stable-diffusion/scripts/img2img.py", line 20, in <module>
    from ldm.util import instantiate_from_config
ModuleNotFoundError: No module named 'ldm'
```
This follows the pattern in txt2img.py to resolve the path, which resolves the error.

This closed issue is for the same problem (but they just fixed it locally): https://github.com/CompVis/stable-diffusion/issues/160