### PR TITLE
Get rid of DeprecationWarning, clean up PIL imports

### DIFF
--- a/ldm/data/imagenet.py
+++ b/ldm/data/imagenet.py
@@ -1,7 +1,6 @@
 import os, yaml, pickle, shutil, tarfile, glob
 import cv2
 import albumentations
-import PIL
 import numpy as np
 import torchvision.transforms.functional as TF
 from omegaconf import OmegaConf
@@ -316,12 +315,12 @@ class ImageNetSR(Dataset):
             "cv_bicubic": cv2.INTER_CUBIC,
             "cv_area": cv2.INTER_AREA,
             "cv_lanczos": cv2.INTER_LANCZOS4,
-            "pil_nearest": PIL.Image.NEAREST,
-            "pil_bilinear": PIL.Image.BILINEAR,
-            "pil_bicubic": PIL.Image.BICUBIC,
-            "pil_box": PIL.Image.BOX,
-            "pil_hamming": PIL.Image.HAMMING,
-            "pil_lanczos": PIL.Image.LANCZOS,
+            "pil_nearest": Image.NEAREST,
+            "pil_bilinear": Image.BILINEAR,
+            "pil_bicubic": Image.BICUBIC,
+            "pil_box": Image.BOX,
+            "pil_hamming": Image.HAMMING,
+            "pil_lanczos": Image.Resampling.LANCZOS,
             }[degradation]
 
             self.pil_interpolation = degradation.startswith("pil_")
@@ -359,7 +358,7 @@ class ImageNetSR(Dataset):
         image = self.image_rescaler(image=image)["image"]
 
         if self.pil_interpolation:
-            image_pil = PIL.Image.fromarray(image)
+            image_pil = Image.fromarray(image)
             LR_image = self.degradation_process(image_pil)
             LR_image = np.array(LR_image).astype(np.uint8)
 

--- a/ldm/data/lsun.py
+++ b/ldm/data/lsun.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-import PIL
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision import transforms
@@ -26,10 +25,10 @@ class LSUNBase(Dataset):
         }
 
         self.size = size
-        self.interpolation = {"linear": PIL.Image.LINEAR,
-                              "bilinear": PIL.Image.BILINEAR,
-                              "bicubic": PIL.Image.BICUBIC,
-                              "lanczos": PIL.Image.LANCZOS,
+        self.interpolation = {"linear": Image.LINEAR,
+                              "bilinear": Image.BILINEAR,
+                              "bicubic": Image.BICUBIC,
+                              "lanczos": Image.Resampling.LANCZOS,
                               }[interpolation]
         self.flip = transforms.RandomHorizontalFlip(p=flip_p)
 

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -1,7 +1,6 @@
 """make variations of input image"""
 
 import argparse, os, sys, glob
-import PIL
 import torch
 import numpy as np
 from omegaconf import OmegaConf
@@ -50,7 +49,7 @@ def load_img(path):
     w, h = image.size
     print(f"loaded input image of size ({w}, {h}) from {path}")
     w, h = map(lambda x: x - x % 32, (w, h))  # resize to integer multiple of 32
-    image = image.resize((w, h), resample=PIL.Image.LANCZOS)
+    image = image.resize((w, h), resample=Image.Resampling.LANCZOS)
     image = np.array(image).astype(np.float32) / 255.0
     image = image[None].transpose(0, 3, 1, 2)
     image = torch.from_numpy(image)


### PR DESCRIPTION
Gets rid of this warning being shown each time you run e.g. `scripts/img2img.py`
```
DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
```