### PR TITLE
Add fprefix command argument

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -226,6 +226,11 @@ def main():
         choices=["full", "autocast"],
         default="autocast"
     )
+    parser.add_argument(
+        "--fprefix",
+        type=str,
+        help="filename prefix for sample outputs"
+    )
     opt = parser.parse_args()
 
     if opt.laion400m:
@@ -315,7 +320,7 @@ def main():
                                 x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
                                 img = Image.fromarray(x_sample.astype(np.uint8))
                                 img = put_watermark(img, wm_encoder)
-                                img.save(os.path.join(sample_path, f"{base_count:05}.png"))
+                                img.save(os.path.join(sample_path, f"{opt.fprefix or ''}{base_count:05}.png"))
                                 base_count += 1
 
                         if not opt.skip_grid:


### PR DESCRIPTION
Add fprefix command argument. Permits an arbitrarily configured "filename prefix".

Ex: python scripts/txt2img.py --plms --n_iter 5 --n_samples 1 --skip_grid --fprefix 2022.09.10-0312- --prompt "a photograph of an astronaut riding a horse"
Results in sample filename: "2022.09.10-0312-00128.png", and etc.

I found use for this argument. Figured I'd contribute, and maybe someone else will also find this useful.