### PR TITLE
Limit pandas version that does not support requested numpy version

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -26,6 +26,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
+    - pandas<1.5.0
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .


### PR DESCRIPTION
```
RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd
ImportError: this version of pandas is incompatible with numpy < 1.20.3
your numpy version is 1.19.2.
```