### PR TITLE
Fix the expected name of the from_file argument in txt2img

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -197,7 +197,7 @@ def main():
         help="unconditional guidance scale: eps = eps(x, empty) + scale * (eps(x, cond) - eps(x, empty))",
     )
     parser.add_argument(
-        "--from-file",
+        "--from_file",
         type=str,
         help="if specified, load prompts from this file",
     )


### PR DESCRIPTION
The argument parser expects an argument with the name `from-file` but the code looks for `from_file`. This issue doesn't crash the code but may be confusing for users of the script - it would cause strange behaviour.

In more details:
```
parser.add_argument(
    "--from-file",
```

And later in the code:
```
if not opt.from_file:
...
```

Note that the ArgumentParser looks flexible enough to accept unknown arguments but if someone reads the code and tries to enter `from-file` they may have troubles down the road when `opt.from_file` is not found and prompts won't be loaded from a file.