### PR TITLE
Generate a torch.arange directly on the correct device, presumably a GPU

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -160,8 +160,8 @@ def timestep_embedding(timesteps, dim, max_period=10000, repeat_only=False):
     if not repeat_only:
         half = dim // 2
         freqs = torch.exp(
-            -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
-        ).to(device=timesteps.device)
+            -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32, device=timesteps.device) / half
+        )
         args = timesteps[:, None].float() * freqs[None]
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
         if dim % 2:


### PR DESCRIPTION
Hi, I think this is my first ever pull request on a public project.

Anyway, I used the [Scalene](https://github.com/plasma-umass/scalene) profiler when running a [LDSR](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/ea5b90b3b35985b4eff50d5fdb6000c9475af4cb/modules/ldsr_model_arch.py) upscaler and I noticed that this calculation was being first done on a CPU, and only then the outcome was moved to GPU. This patch calculates `freqs` directly on the GPU, if that is the `timesteps.device`.

In my tests with a Nvidia 3070 card this saves about 17% of the processing time, which is quite significant for such a small change.