### PR TITLE
Correct timestep for initial noise addition

### DIFF
--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -256,7 +256,7 @@ def main():
                         c = model.get_learned_conditioning(prompts)
 
                         # encode (scaled latent)
-                        z_enc = sampler.stochastic_encode(init_latent, torch.tensor([t_enc]*batch_size).to(device))
+                        z_enc = sampler.stochastic_encode(init_latent, torch.tensor([t_enc - 1]*batch_size).to(device))
                         # decode it
                         samples = sampler.decode(z_enc, c, t_enc, unconditional_guidance_scale=opt.scale,
                                                  unconditional_conditioning=uc,)


### PR DESCRIPTION
After some experimentation, I am pretty sure that the wrong timestep is used for the additive noise for image-2-image.

Essentially what is happening here is that `t+1` is used as the timestep to add noise to the original image, but `[0, ..., t]` is used afterwards for the denoising process. We should however also use `t` when adding the noise to the original image.

This can be quite easily verified by doing the following. Run a img2img with a small number of update steps and a very low strength because then differences between t and t+1 become quite clear. 

E.g. when I run:
```
python scripts/img2img.py --prompt "A fantasy landscape, trending on artstation" --init-img ./sketch-mountains-input.jpg --strength 0.1 --seed 42 --n_samples 1 --ddim_steps 10
```

With the current code, I get the following output:
![orig_sketch (1)](https://user-images.githubusercontent.com/23423619/206869847-02d16c74-f557-456a-9679-5f1f6e4248f2.png)

After the fix, I get some output which has much less noise, therefore showcasing that the noise addition and consecutive denoising process matches:
![corr_sketch (1)](https://user-images.githubusercontent.com/23423619/206869892-58998fb8-39c5-4f40-bc5f-85f157fc628f.png)
