### PR TITLE
Add negative_prompt to txt2img and img2img

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,14 @@ and renders images of size 512x512 (which it was trained on) in 50 steps. All su
 
 
 ```commandline
-usage: txt2img.py [-h] [--prompt [PROMPT]] [--outdir [OUTDIR]] [--skip_grid] [--skip_save] [--ddim_steps DDIM_STEPS] [--plms] [--laion400m] [--fixed_code] [--ddim_eta DDIM_ETA]
+usage: txt2img.py [-h] [--prompt [PROMPT]] [--negative_prompt] [--outdir [OUTDIR]] [--skip_grid] [--skip_save] [--ddim_steps DDIM_STEPS] [--plms] [--laion400m] [--fixed_code] [--ddim_eta DDIM_ETA]
                   [--n_iter N_ITER] [--H H] [--W W] [--C C] [--f F] [--n_samples N_SAMPLES] [--n_rows N_ROWS] [--scale SCALE] [--from-file FROM_FILE] [--config CONFIG] [--ckpt CKPT]
                   [--seed SEED] [--precision {full,autocast}]
 
 optional arguments:
   -h, --help            show this help message and exit
   --prompt [PROMPT]     the prompt to render
+  --negative_prompt     the negative prompt to render
   --outdir [OUTDIR]     dir to write results to
   --skip_grid           do not save a grid, only individual samples. Helpful when evaluating lots of samples
   --skip_save           do not save individual samples. For speed measurements.

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -259,7 +259,9 @@ def main():
                     for prompts in tqdm(data, desc="data"):
                         uc = None
                         if negative_prompt:
-                            uc = model.get_learned_conditioning(len(prompts) * [negative_prompt])
+                            uc = model.get_learned_conditioning(batch_size * [negative_prompt])
+                        elif opt.scale != 1.0:
+                            uc = model.get_learned_conditioning(batch_size * [""]
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
                         c = model.get_learned_conditioning(prompts)

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -67,7 +67,15 @@ def main():
         default="a painting of a virus monster playing guitar",
         help="the prompt to render"
     )
-
+    
+    parser.add_argument(
+        "--negative_prompt",
+        type=str,
+        nargs="?",
+        default="",
+        help="the negative prompt to render"
+    )
+    
     parser.add_argument(
         "--init-img",
         type=str,
@@ -215,6 +223,7 @@ def main():
     n_rows = opt.n_rows if opt.n_rows > 0 else batch_size
     if not opt.from_file:
         prompt = opt.prompt
+        negative_prompt = opt.negative_prompt
         assert prompt is not None
         data = [batch_size * [prompt]]
 
@@ -249,8 +258,8 @@ def main():
                 for n in trange(opt.n_iter, desc="Sampling"):
                     for prompts in tqdm(data, desc="data"):
                         uc = None
-                        if opt.scale != 1.0:
-                            uc = model.get_learned_conditioning(batch_size * [""])
+                        if negative_prompt:
+                            uc = model.get_learned_conditioning(len(prompts) * [negative_prompt])
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
                         c = model.get_learned_conditioning(prompts)

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -305,7 +305,10 @@ def main():
                     for prompts in tqdm(data, desc="data"):
                         uc = None
                         if negative_prompt:
-                            uc = model.get_learned_conditioning(len(prompts) * [negative_prompt])
+                            uc = model.get_learned_conditioning(batch_size * [negative_prompt])
+                        elif opt.scale != 1.0:
+                            uc = model.get_learned_conditioning(batch_size * [""])
+                            
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
                         c = model.get_learned_conditioning(prompts)

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -105,6 +105,15 @@ def main():
         default="a painting of a virus monster playing guitar",
         help="the prompt to render"
     )
+    
+    parser.add_argument(
+        "--negative_prompt",
+        type=str,
+        nargs="?",
+        default="",
+        help="the negative prompt to render"
+    )
+    
     parser.add_argument(
         "--outdir",
         type=str,
@@ -267,6 +276,7 @@ def main():
     n_rows = opt.n_rows if opt.n_rows > 0 else batch_size
     if not opt.from_file:
         prompt = opt.prompt
+        negative_prompt = opt.negative_prompt
         assert prompt is not None
         data = [batch_size * [prompt]]
 
@@ -294,8 +304,8 @@ def main():
                 for n in trange(opt.n_iter, desc="Sampling"):
                     for prompts in tqdm(data, desc="data"):
                         uc = None
-                        if opt.scale != 1.0:
-                            uc = model.get_learned_conditioning(batch_size * [""])
+                        if negative_prompt:
+                            uc = model.get_learned_conditioning(len(prompts) * [negative_prompt])
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
                         c = model.get_learned_conditioning(prompts)


### PR DESCRIPTION
# Overview
I add negative_prompt to txt2img and img2img
I think it will be more useful for image generation!

## Example
Other parameters are the same.

### Before
![grid-0000](https://user-images.githubusercontent.com/63702646/210166204-a04bc708-eb44-4225-abfc-0fc646f3387a.png)
### After add negative_prompt
![grid-0006](https://user-images.githubusercontent.com/63702646/210166218-388d215f-7fae-4435-b442-4391c1cb1673.png)

```
prompt 
((masterpiece)), (((best quality))), ((ultra-detailed)), ((illustration)), ((disheveled hair)), ((frills)), (1 girl), (solo), dynamic angle, big top sleeves, floating, beautiful detailed sky, on beautiful detailed water, beautiful detailed eyes, overexposure, (fist), expressionless, side blunt bangs, hairs between eyes, ribbons, bowties, buttons, bare shoulders, (((small breast))), detailed wet clothes, blank stare, pleated skirt, flowers
```

```
negative_prompt 
owres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry,missing fingers,bad hands,missing arms, long neck, Humpbacked```