### PR TITLE
Add prompt weights to the txt2img script

### DIFF
--- a/ldm/prompt_weights.py
+++ b/ldm/prompt_weights.py
@@ -1,0 +1,57 @@
+import re
+
+# When using prompt weights, use this to recover the original non-weighted prompt
+prompt_filter_regex = r"[\(\)]|:\d+(\.\d+)?"
+
+
+# We subtract the conditioning of the full prompt without the subprompt, from the conditioning of the full prompt
+# The remainder is exactly what the subprompt 'adds' to the embedding vector in the context of the full prompt
+# Then, we use this value to update the current embedding vector according to the desired weight of the subprompt
+def update_conditioning(filtered_whole_prompt, filtered_whole_prompt_c, model, current_prompt_c, subprompt, weight):
+    prompt_wo_subprompt = filtered_whole_prompt.replace(subprompt, "")
+    prompt_wo_subprompt_c = model.get_learned_conditioning(prompt_wo_subprompt)
+    subprompt_contribution_to_c = filtered_whole_prompt_c - prompt_wo_subprompt_c
+    current_prompt_c += (weight - 1.0) * subprompt_contribution_to_c
+    return current_prompt_c
+
+
+def get_learned_conditioning_with_prompt_weights(prompt, model):
+    # Get a filtered prompt without (, ), and :number + conditioning
+    filtered_whole_prompt = re.sub(prompt_filter_regex, "", prompt)
+
+    # Get full prompt embedding vector
+    filtered_whole_prompt_c = model.get_learned_conditioning(filtered_whole_prompt)
+    current_prompt_c = filtered_whole_prompt_c
+
+    # Find the first () delimited subprompt
+    subprompt_open_i = prompt.find("(")
+    subprompt_close_i = prompt.find(")", subprompt_open_i + 1)
+
+    # Process the (next) subprompt
+    while subprompt_open_i != -1 and subprompt_close_i != -1:
+        subprompt = prompt[subprompt_open_i + 1 : subprompt_close_i]
+        weight_i = subprompt.find(":")
+        subprompt_wo_weight = subprompt[0:weight_i]
+
+        # Process the weight if we have it
+        if weight_i != -1:
+            weight_str = subprompt[weight_i + 1 :]
+            try:
+                weight_val = float(weight_str)
+                # Update the conditioning with this subprompt and weight
+                current_prompt_c = update_conditioning(
+                    filtered_whole_prompt,
+                    filtered_whole_prompt_c,
+                    model,
+                    current_prompt_c,
+                    subprompt_wo_weight,
+                    weight_val,
+                )
+            except ValueError:
+                pass
+
+        # Find next () delimited subprompt
+        subprompt_open_i = prompt.find("(", subprompt_open_i + 1)
+        subprompt_close_i = prompt.find(")", subprompt_open_i + 1)
+
+    return current_prompt_c

--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -18,6 +18,7 @@ from pytorch_lightning import seed_everything
 from ldm.util import instantiate_from_config
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler
+from ldm.prompt_weights import get_learned_conditioning_with_prompt_weights
 
 
 def chunk(it, size):
@@ -253,7 +254,8 @@ def main():
                             uc = model.get_learned_conditioning(batch_size * [""])
                         if isinstance(prompts, tuple):
                             prompts = list(prompts)
-                        c = model.get_learned_conditioning(prompts)
+                        c = torch.cat([get_learned_conditioning_with_prompt_weights(prompt, model)
+                                       for prompt in prompts])
 
                         # encode (scaled latent)
                         z_enc = sampler.stochastic_encode(init_latent, torch.tensor([t_enc]*batch_size).to(device))

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -18,6 +18,7 @@ from ldm.util import instantiate_from_config
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.models.diffusion.dpm_solver import DPMSolverSampler
+from ldm.prompt_weights import get_learned_conditioning_with_prompt_weights
 
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from transformers import AutoFeatureExtractor
@@ -96,56 +97,6 @@ def check_safety(x_image):
             x_checked_image[i] = load_replacement(x_checked_image[i])
     return x_checked_image, has_nsfw_concept
 
-# We subtract the conditioning of the full prompt without the subprompt, from the conditioning of the full prompt
-# The remainder is exactly what the subprompt 'adds' to the embedding vector in the context of the full prompt
-# Then, we use this value to update the current embedding vector according to the desired weight of the subprompt
-def update_conditioning(filtered_whole_prompt, filtered_whole_prompt_c, model, current_prompt_c, subprompt, weight):
-    prompt_wo_subprompt = filtered_whole_prompt.replace(subprompt, "")
-    prompt_wo_subprompt_c = model.get_learned_conditioning(prompt_wo_subprompt)
-    subprompt_contribution_to_c = filtered_whole_prompt_c - prompt_wo_subprompt_c
-    current_prompt_c += (weight - 1.0) * subprompt_contribution_to_c
-    return current_prompt_c
-
-
-def get_learned_conditioning_with_prompt_weights(prompt, model):
-    # Get a filtered prompt without (, ), and :number + conditioning
-    filtered_whole_prompt = re.sub(prompt_filter_regex, '', prompt)
-
-    # Get full prompt embedding vector
-    filtered_whole_prompt_c = model.get_learned_conditioning(filtered_whole_prompt)
-    current_prompt_c = filtered_whole_prompt_c
-
-    # Find the first () delimited subprompt
-    subprompt_open_i = prompt.find("(")
-    subprompt_close_i = prompt.find(")", subprompt_open_i+1)
-
-    # Process the (next) subprompt
-    while subprompt_open_i != -1 and subprompt_close_i != -1:
-        subprompt = prompt[subprompt_open_i + 1 : subprompt_close_i]
-        weight_i = subprompt.find(":")
-        subprompt_wo_weight = subprompt[0:weight_i]
-
-        # Process the weight if we have it
-        if weight_i != -1:
-            weight_str = subprompt[weight_i + 1:]
-            try:
-                weight_val = float(weight_str)
-                # Update the conditioning with this subprompt and weight
-                print(f"Adjusting {subprompt_wo_weight} to weight {weight_val}")
-                current_prompt_c = update_conditioning(filtered_whole_prompt,
-                                                       filtered_whole_prompt_c,
-                                                       model,
-                                                       current_prompt_c,
-                                                       subprompt_wo_weight,
-                                                       weight_val)
-            except ValueError:
-                pass
-
-        # Find next () delimited subprompt
-        subprompt_open_i = prompt.find("(", subprompt_open_i+1)
-        subprompt_close_i = prompt.find(")", subprompt_open_i+1)
-
-    return current_prompt_c
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)


### PR DESCRIPTION
I've been looking for a good code example to add prompt weights, but most implementations I found just split the prompt in subprompts, and make a weighted average of the embeddings of these subprompts. This has two disadvantages:
- Even adding a small weight tweak to one of the words changes the image completely
- Since the prompt is split, information about the context between words is lost. (which is exactly what transformers are good at)

This implementation takes a different approach; It calculates the difference between the whole prompt with and without the weighted subprompt. It takes this difference to be the contribution of the subprompt to the embedding vector, and uses this to subtly modify the original embedding vector on the weight. Results seem much more stable (small tweaks don't disturb the entire result), and I believe this to be a better method.

Tell me if I'm doing it wrong. :)