### PR TITLE
Undefined name: import matplotlib.pyplot as plt

### DIFF
--- a/ldm/modules/image_degradation/utils_image.py
+++ b/ldm/modules/image_degradation/utils_image.py
@@ -6,7 +6,7 @@ import torch
 import cv2
 from torchvision.utils import make_grid
 from datetime import datetime
-#import matplotlib.pyplot as plt   # TODO: check with Dominik, also bsrgan.py vs bsrgan_light.py
+import matplotlib.pyplot as plt
 
 
 os.environ["KMP_DUPLICATE_LIB_OK"]="TRUE"


### PR DESCRIPTION
`plt` is used on lines 38, 39, 41, 43, 44, 48, 49, and 57 of this file but it is never imported or defined.  This will run successfully if some other file has previously imported `plt` but is fragile because it will break if that other file is modified.

% `flake8 . --count --select=E9,F63,F7,F82,Y --show-source --statistics`
```
./ldm/modules/image_degradation/utils_image.py:38:5: F821 undefined name 'plt'
    plt.figure(figsize=figsize)
    ^
./ldm/modules/image_degradation/utils_image.py:39:5: F821 undefined name 'plt'
    plt.imshow(np.squeeze(x), interpolation='nearest', cmap='gray')
    ^
./ldm/modules/image_degradation/utils_image.py:41:9: F821 undefined name 'plt'
        plt.title(title)
        ^
./ldm/modules/image_degradation/utils_image.py:43:9: F821 undefined name 'plt'
        plt.colorbar()
        ^
./ldm/modules/image_degradation/utils_image.py:44:5: F821 undefined name 'plt'
    plt.show()
    ^
./ldm/modules/image_degradation/utils_image.py:48:5: F821 undefined name 'plt'
    plt.figure(figsize=figsize)
    ^
./ldm/modules/image_degradation/utils_image.py:49:11: F821 undefined name 'plt'
    ax3 = plt.axes(projection='3d')
          ^
./ldm/modules/image_degradation/utils_image.py:57:5: F821 undefined name 'plt'
    plt.show()
    ^
```