### PR TITLE
fix diffuser version

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - numpy=1.19.2
   - pip:
     - albumentations==0.4.3
-    - diffusers
+    - diffusers==0.12.1
     - opencv-python==4.1.2.30
     - pudb==2019.2
     - invisible-watermark


### PR DESCRIPTION
actually launching inference throw this error 

`ImportError: cannot import name 'SAFE_WEIGHTS_NAME' from 'transformers.utils' (/home/diamondra/miniconda3/envs/ldm/lib/python3.8/site-packages/transformers/utils/__init__.py)`

fixing version of diffusers to 0.12.1 make it works properly