### PR TITLE
Set dependency version for diffusers to prevent dependency mismatch

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - numpy=1.19.2
   - pip:
     - albumentations==0.4.3
-    - diffusers
+    - diffusers==0.7.2
     - opencv-python==4.1.2.30
     - pudb==2019.2
     - invisible-watermark


### PR DESCRIPTION
Set version for diffusers to prevent version mismatch with dependency transformers==4.19.2 