### PR TITLE
Fixes in ddpm.py and main.py

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -1027,7 +1027,7 @@ class LatentDiffusion(DDPM):
         loss_simple = self.get_loss(model_output, target, mean=False).mean([1, 2, 3])
         loss_dict.update({f'{prefix}/loss_simple': loss_simple.mean()})
 
-        logvar_t = self.logvar[t].to(self.device)
+        logvar_t = self.logvar.to(self.device)[t]
         loss = loss_simple / torch.exp(logvar_t) + logvar_t
         # loss = loss_simple / torch.exp(self.logvar) + self.logvar
         if self.learn_logvar:

--- a/main.py
+++ b/main.py
@@ -400,7 +400,7 @@ class CUDACallback(Callback):
         torch.cuda.synchronize(trainer.root_gpu)
         self.start_time = time.time()
 
-    def on_train_epoch_end(self, trainer, pl_module, outputs):
+    def on_train_epoch_end(self, trainer, pl_module):
         torch.cuda.synchronize(trainer.root_gpu)
         max_memory = torch.cuda.max_memory_allocated(trainer.root_gpu) / 2 ** 20
         epoch_time = time.time() - self.start_time


### PR DESCRIPTION
1. first move `self.logvar` to `self.device`, and then index using `t` (line 1030, ddpm.py)
the current verison of the code gives the following error:
```
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```


2. remove extraneous argument `outputs` from `on_train_epoch_end` in `main.py`
the current version of the code gives the following error:

```
TypeError: on_train_epoch_end() missing 1 required positional argument: 'outputs'
```