### PR TITLE
fix: NaN assertion uses .all() instead of .any()

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -166,7 +166,7 @@ class DDPM(pl.LightningModule):
         # TODO how to choose this term
         lvlb_weights[0] = lvlb_weights[1]
         self.register_buffer('lvlb_weights', lvlb_weights, persistent=False)
-        assert not torch.isnan(self.lvlb_weights).all()
+        assert not torch.isnan(self.lvlb_weights).any()
 
     @contextmanager
     def ema_scope(self, context=None):


### PR DESCRIPTION
## Bug
The NaN assertion `assert not torch.isnan(x).all()` only triggers when ALL values are NaN. The intended check is to catch ANY NaN values, which requires `.any()`.

## Fix
Changed `.all()` to `.any()` so the assertion catches any NaN values.