### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -451,7 +451,7 @@ class LatentDiffusion(DDPM):
         self.cond_stage_key = cond_stage_key
         try:
             self.num_downs = len(first_stage_config.params.ddconfig.ch_mult) - 1
-        except:
+        except Exception:
             self.num_downs = 0
         if not scale_by_std:
             self.scale_factor = scale_factor

--- a/notebook_helpers.py
+++ b/notebook_helpers.py
@@ -261,7 +261,7 @@ def make_convolutional_sample(batch, model, mode="vanilla", custom_steps=None, e
         x_sample_noquant = model.decode_first_stage(sample, force_not_quantize=True)
         log["sample_noquant"] = x_sample_noquant
         log["sample_diff"] = torch.abs(x_sample_noquant - x_sample)
-    except:
+    except Exception:
         pass
 
     log["sample"] = x_sample

--- a/scripts/sample_diffusion.py
+++ b/scripts/sample_diffusion.py
@@ -44,7 +44,7 @@ def logs2pil(logs, keys=["sample"]):
             else:
                 print(f"Unknown format for key {k}. ")
                 img = None
-        except:
+        except Exception:
             img = None
         imgs[k] = img
     return imgs

--- a/scripts/tests/test_watermark.py
+++ b/scripts/tests/test_watermark.py
@@ -9,7 +9,7 @@ def testit(img_path):
     watermark = decoder.decode(bgr, 'dwtDct')
     try:
         dec = watermark.decode('utf-8')
-    except:
+    except Exception:
         dec = "null"
     print(dec)
 


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.